### PR TITLE
feat: hide npc buy offers if player lacks items

### DIFF
--- a/data/scripts/talkactions/player/emote_spell.lua
+++ b/data/scripts/talkactions/player/emote_spell.lua
@@ -2,16 +2,22 @@
 local emoteSpell = TalkAction("!emote")
 
 function emoteSpell.onSay(player, words, param)
-	if param == "" then
-		player:sendCancelMessage("You need to specify on/off param.")
+	if configManager.getBoolean(configKeys.EMOTE_SPELLS) == false then
+		player:sendTextMessage(MESSAGE_LOOK, "Emote spells have been disabled by the administrator.")
 		return true
 	end
+
+	if param == "" then
+		player:sendCancelMessage("Please specify the parameter: 'on' to activate or 'off' to deactivate.")
+		return true
+	end
+
 	if param == "on" then
 		player:setStorageValue(STORAGEVALUE_EMOTE, 1)
-		player:sendTextMessage(MESSAGE_LOOK, "You activated emoted spells")
+		player:sendTextMessage(MESSAGE_LOOK, "You have activated emote spells.")
 	elseif param == "off" then
 		player:setStorageValue(STORAGEVALUE_EMOTE, 0)
-		player:sendTextMessage(MESSAGE_LOOK, "You desactivated emoted spells")
+		player:sendTextMessage(MESSAGE_LOOK, "You have deactivated emote spells.")
 	end
 	return true
 end

--- a/data/scripts/talkactions/player/flask.lua
+++ b/data/scripts/talkactions/player/flask.lua
@@ -6,12 +6,10 @@ function flask.onSay(player, words, param)
 		return true
 	end
 	if param == "on" and player:getStorageValueByName("talkaction.potions.flask") ~= 1 then
-		player:setStorageValue(STORAGEVALUE_EMOTE, 1)
 		player:setStorageValueByName("talkaction.potions.flask", 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You will not receive flasks!")
 		player:getPosition():sendMagicEffect(CONST_ME_REDSMOKE)
 	elseif param == "off" then
-		player:setStorageValue(STORAGEVALUE_EMOTE, 0)
 		player:setStorageValueByName("talkaction.potions.flask", 0)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You will receive flasks.")
 		player:getPosition():sendMagicEffect(CONST_ME_REDSMOKE)

--- a/data/scripts/talkactions/player/hidden_npc_sell_shop_items.lua
+++ b/data/scripts/talkactions/player/hidden_npc_sell_shop_items.lua
@@ -1,0 +1,20 @@
+local talkaction = TalkAction("!hiddenshop")
+
+function talkaction.onSay(player, words, param)
+	if param == "" then
+		player:sendCancelMessage("You need to specify on/off param.")
+		return true
+	end
+	if param == "on" then
+		player:kv():set("npc-shop-hidden-sell-item", true)
+		player:sendTextMessage(MESSAGE_LOOK, "You activated hidden sell shop items.")
+	elseif param == "off" then
+		player:kv():set("npc-shop-hidden-sell-item", false)
+		player:sendTextMessage(MESSAGE_LOOK, "You desactivated hidden sell shop items")
+	end
+	return true
+end
+
+talkaction:separator(" ")
+talkaction:groupType("normal")
+talkaction:register()

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -381,7 +381,7 @@ void Npc::onPlayerSellItem(std::shared_ptr<Player> player, uint16_t itemId, uint
 	}
 
 	auto toRemove = amount;
-	for (auto inventoryItems = player->getInventoryItemsFromId(itemId, ignore); auto item : inventoryItems) {
+	for (auto item : player->getInventoryItemsFromId(itemId, ignore)) {
 		if (!item || item->getTier() > 0 || item->hasImbuements()) {
 			continue;
 		}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6820,7 +6820,9 @@ bool Player::saySpell(
 	// Send to client
 	for (std::shared_ptr<Creature> spectator : spectators) {
 		if (std::shared_ptr<Player> tmpPlayer = spectator->getPlayer()) {
-			valueEmote = tmpPlayer->getStorageValue(STORAGEVALUE_EMOTE);
+			if (g_configManager().getBoolean(EMOTE_SPELLS, __FUNCTION__)) {
+				valueEmote = tmpPlayer->getStorageValue(STORAGEVALUE_EMOTE);
+			}
 			if (!ghostMode || tmpPlayer->canSeeCreature(static_self_cast<Player>())) {
 				if (valueEmote == 1) {
 					tmpPlayer->sendCreatureSay(static_self_cast<Player>(), TALKTYPE_MONSTER_SAY, text, pos);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7655,6 +7655,18 @@ void ProtocolGame::AddShopItem(NetworkMessage &msg, const ShopBlock &shopBlock) 
 		return;
 	}
 
+	// Hidden sell items from the shop if they are not in the player's inventory
+	auto talkactionHidden = player->kv()->get("npc-shop-hidden-sell-item");
+	if (talkactionHidden && talkactionHidden->get<BooleanType>() == true) {
+		std::map<uint16_t, uint16_t> inventoryMap;
+		player->getAllSaleItemIdAndCount(inventoryMap);
+		auto inventoryItems = inventoryMap.find(shopBlock.itemId);
+		if (inventoryItems == inventoryMap.end() && shopBlock.itemSellPrice > 0 && shopBlock.itemBuyPrice == 0) {
+			AddHiddenShopItem(msg);
+			return;
+		}
+	}
+
 	const ItemType &it = Item::items[shopBlock.itemId];
 	msg.add<uint16_t>(shopBlock.itemId);
 	if (it.isSplash() || it.isFluidContainer()) {


### PR DESCRIPTION
• Hides NPC sell offers if player lacks items.
• Added a talkaction to toggle the feature, allowing players to manage its use. • Enhanced '!emote' talkaction: now accessible only if enabled by the admin in config.lua.


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
